### PR TITLE
Separate client mount options from export options

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Finally:
 
  - storage_root: The root path where exported directories will be created
  - export_options: The default export options. Ships with rw,sync,no_root_squash,no_all_squash
+ - mount_options: The default client mount options
 
 # Contact Information
 

--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,10 @@ options:
     type: string
     default: rw,sync,no_root_squash,no_all_squash,no_subtree_check
     description: The default export options
+  mount_options:
+    type: string
+    default: defaults
+    description: The default client mount options
   initial_daemon_count:
     type: int
     default: 40

--- a/reactive/nfs.py
+++ b/reactive/nfs.py
@@ -90,7 +90,8 @@ def nfs_relation_changed():
 
     config = hookenv.config()
     storage_root = config.get('storage_root')
-    options = config.get('export_options')
+    export_options = config.get('export_options')
+    mount_options = config.get('mount_options')
 
     # get desired mounts
     mount_list = mount_interface.get_mount_requests()
@@ -118,7 +119,8 @@ def nfs_relation_changed():
             'mountpoint': path,
             'identifier': mount['identifier'],
             'fstype': 'nfs',
-            'options': options,
+            'export_options': export_options,
+            'options': mount_options,
         })
 
     if len(template_context['mounts']) == 0:

--- a/templates/export.tpl
+++ b/templates/export.tpl
@@ -1,2 +1,2 @@
-{% for mount in mounts %}{{ mount.mountpoint }}{% for addr in mount.addresses %} {{ addr }}({{mount.options}}){% endfor %}
+{% for mount in mounts %}{{ mount.mountpoint }}{% for addr in mount.addresses %} {{ addr }}({{mount.export_options}}){% endfor %}
 {% endfor %}


### PR DESCRIPTION
The options that go into /etc/exports on an NFS server aren't drawn from
the same vocabulary as those that go into /etc/fstab on an NFS client,
even though a few of them happen to overlap.  Passing the export options
to the mount interface is an indication that the client should try to
use them as mount options; indeed, the "storage" subordinate charm does
just that and fails because things like "no_root_squash" aren't valid
mount options.  It's therefore necessary to separate these two concepts.

Leaving the mount options at "defaults" will probably be just fine in
most cases, but just in case I've added a "mount_options" configuration
option.