### PR TITLE
Fix refresh_nfs_mounts flag name

### DIFF
--- a/reactive/nfs.py
+++ b/reactive/nfs.py
@@ -71,7 +71,7 @@ def read_nfs_mounts():
             return
 
 
-@when_not('nfs.changed', 'nfs_refresh_mounts')
+@when_not('nfs.changed', 'refresh_nfs_mounts')
 @when('nfs_installed')
 def idle_status():
     hookenv.status_set('active', 'NFS ready')


### PR DESCRIPTION
The idle_status used the wrong flag name for whether NFS mounts need to
be refreshed, so it would set the active status a little too early.