### PR TITLE
Exclude builds and deps from charm build

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -1,4 +1,6 @@
 includes:
   - 'layer:basic'
   - 'interface:mount'
-
+exclude:
+  - builds
+  - deps


### PR DESCRIPTION
This makes it a bit easier to test changes to this charm via `charm
build .`.