### PR TITLE
Avoid duplicate exports

### DIFF
--- a/reactive/nfs.py
+++ b/reactive/nfs.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 import os
 
 from charmhelpers.core import hookenv
@@ -96,8 +97,8 @@ def nfs_relation_changed():
     # get desired mounts
     mount_list = mount_interface.get_mount_requests()
 
-    template_context = {}
-    template_context['mounts'] = []
+    mount_addresses = defaultdict(set)
+    mount_responses = []
 
     for mount in mount_list:
         if not mount['application_name']:
@@ -113,21 +114,27 @@ def nfs_relation_changed():
             # have a choice.
             os.chmod(path, 0o777)
 
-        template_context['mounts'].append({
+        mount_addresses[path].update(mount['addresses'])
+        mount_responses.append({
             'export_name': mount['application_name'],
-            'addresses': mount['addresses'],
             'mountpoint': path,
             'identifier': mount['identifier'],
             'fstype': 'nfs',
-            'export_options': export_options,
             'options': mount_options,
         })
 
-    if len(template_context['mounts']) == 0:
-        os.remove(EXPORT_FILENAME)
-    else:
+    if mount_addresses:
+        template_context = {
+            'mounts': [{
+                'mountpoint': path,
+                'addresses': sorted(mount_addresses[path]),
+                'export_options': export_options,
+            } for path in sorted(mount_addresses)],
+        }
         render('export.tpl', EXPORT_FILENAME, template_context)
         hookenv.log('rendering template to {}'.format(EXPORT_FILENAME))
+    else:
+        os.remove(EXPORT_FILENAME)
 
     set_flag('refresh_nfs_mounts')
-    mount_interface.configure(template_context['mounts'])
+    mount_interface.configure(mount_responses)


### PR DESCRIPTION
https://github.com/juju-solutions/interface-mount/pull/4 allows for multiple
mount requests to share the same export name.  This could previously have
caused this charm to write an exports file with duplicate lines, which in turn
caused `exportfs` to issue a "duplicated export entries" error message and exit
with status 1.

`nfs_relation_changed` now deduplicates the lines it writes to its exports
file.  It still needs to send an appropriate response to each `mount` relation,
so it now keeps track of those responses separately.