### PR TITLE
Add active_units configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,31 @@ The above example deploys OwnCloud personal cloud storage, and provides remote s
 	juju add-relation mysql:db wordpress:db
 	juju add-relation nfs:nfs wordpress:nfs
 
+## Migrating Storage
+
+To migrate storage from one NFS unit to another, first add the new unit in
+such a way as to avoid publishing it before it's ready:
+
+	juju config nfs active_units=<old unit ID>
+	juju add-unit nfs
+
+Now start the downtime:
+
+	juju config nfs active_units=none
+
+Wait for all clients to unmount, then move the underlying storage to the new
+unit in whatever way is appropriate for your deployment.
+
+Finish the downtime by publishing the new unit:
+
+	juju config nfs active_units=<new unit ID>
+
+After clients have mounted the new unit and you've checked that all is well,
+you can remove the old unit:
+
+	juju remove-unit <old unit ID>
+	juju config nfs active_units=
+
 ## Known Limitations and Issues
 
 No high availability story

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ you can remove the old unit:
 	juju remove-unit <old unit ID>
 	juju config nfs active_units=
 
+Note that the migration process is quite abrupt: the server does not wait
+for all clients on related units to unmount before stopping.  Consider
+arranging separately for downtime of clients that might write to their NFS
+mounts.
+
 ## Known Limitations and Issues
 
 No high availability story

--- a/config.yaml
+++ b/config.yaml
@@ -15,6 +15,13 @@ options:
     type: int
     default: 40
     description: The number of nfs daemons to run on startup
+  active_units:
+    type: string
+    default: ""
+    description: >
+      If set, a comma-separated list of unit names that should publish data
+      on the 'mount' relation.  This makes it possible to transition
+      gracefully between instances of this application.
   nagios_context:
     default: "juju"
     type: string

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,6 +14,9 @@ provides:
   nrpe-external-master:
     interface: nrpe-external-master
     scope: container
+peers:
+  peer:
+    interface: nfs-peer
 series:
   - bionic
   - xenial

--- a/reactive/nfs.py
+++ b/reactive/nfs.py
@@ -2,8 +2,12 @@ from collections import defaultdict
 import os
 
 from charmhelpers.core import hookenv
-from charmhelpers.core.host import service_start, service_running
-from charmhelpers.core.host import service_restart
+from charmhelpers.core.host import (
+    service_restart,
+    service_running,
+    service_start,
+    service_stop,
+)
 from charmhelpers.fetch import apt_install
 from charms.reactive import when, when_not, when_any, set_flag, clear_flag
 from charms.reactive.relations import endpoint_from_flag
@@ -50,15 +54,21 @@ def update_config():
         service_restart('nfs-kernel-server')
 
 
-@when('refresh_nfs_mounts')
+@when_any('refresh_nfs_mounts',
+          'config.changed.mount_options',
+          'config.changed.active_units')
 def read_nfs_mounts():
+    mount_interface = endpoint_from_flag('endpoint.nfs.joined')
+    if mount_interface is None:
+        hookenv.log('No mount interface, bailing')
+        return
+
     hookenv.status_set('maintenance', 'Updating NFS mounts')
     if service_running('nfs-kernel-server'):
         try:
             command = ['exportfs', '-ra']
             hookenv.log('Executing {}'.format(command))
             check_output(command)
-            clear_flag('refresh_nfs_mounts')
         except CalledProcessError as e:
             hookenv.log(e)
             hookenv.log('Failed to reread nfs mounts. Will attempt again next update.')  # noqa
@@ -70,6 +80,38 @@ def read_nfs_mounts():
             hookenv.log(e)
             hookenv.log('Unable to start service nfs-kernel-server! Will attempt again next update.') # noqa
             return
+
+    config = hookenv.config()
+    active_units = config.get('active_units', '')
+    if not active_units or hookenv.local_unit() in active_units.split(','):
+        storage_root = config.get('storage_root')
+        mount_options = config.get('mount_options')
+        mount_responses = []
+        for mount in mount_interface.get_mount_requests():
+            if not mount['application_name']:
+                continue
+            path = os.path.join(storage_root, mount['application_name'])
+            mount_responses.append({
+                'export_name': mount['application_name'],
+                'mountpoint': path,
+                'identifier': mount['identifier'],
+                'fstype': 'nfs',
+                'options': mount_options,
+            })
+        mount_interface.configure(mount_responses)
+    else:
+        hookenv.log('Disabled (not in active_units)')
+        for relation in mount_interface.relations:
+            relation.to_publish_raw.update({
+                'mountpoint': None,
+                'hostname': None,
+                'fstype': None,
+                'options': None,
+            })
+        if service_running('nfs-kernel-server'):
+            service_stop('nfs-kernel-server')
+
+    clear_flag('refresh_nfs_mounts')
 
 
 @when_not('nfs.changed', 'refresh_nfs_mounts')
@@ -92,13 +134,11 @@ def nfs_relation_changed():
     config = hookenv.config()
     storage_root = config.get('storage_root')
     export_options = config.get('export_options')
-    mount_options = config.get('mount_options')
 
     # get desired mounts
     mount_list = mount_interface.get_mount_requests()
 
     mount_addresses = defaultdict(set)
-    mount_responses = []
 
     for mount in mount_list:
         if not mount['application_name']:
@@ -115,13 +155,6 @@ def nfs_relation_changed():
             os.chmod(path, 0o777)
 
         mount_addresses[path].update(mount['addresses'])
-        mount_responses.append({
-            'export_name': mount['application_name'],
-            'mountpoint': path,
-            'identifier': mount['identifier'],
-            'fstype': 'nfs',
-            'options': mount_options,
-        })
 
     if mount_addresses:
         template_context = {
@@ -137,4 +170,3 @@ def nfs_relation_changed():
         os.remove(EXPORT_FILENAME)
 
     set_flag('refresh_nfs_mounts')
-    mount_interface.configure(mount_responses)

--- a/reactive/nfs.py
+++ b/reactive/nfs.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 import os
+import re
 
 from charmhelpers.core import hookenv
 from charmhelpers.core.host import (
@@ -87,7 +88,7 @@ def read_nfs_mounts():
         peer_endpoint = endpoint_from_name('peer')
         if peer_endpoint is not None:
             peer_info = peer_endpoint.get_peer_info()
-            for active_unit in active_units.split(','):
+            for active_unit in re.split(r'\s*,\s*', active_units):
                 if active_unit in peer_info:
                     active_ip = peer_info[active_unit]['address']
                     hookenv.log(

--- a/reactive/nfs.py
+++ b/reactive/nfs.py
@@ -54,15 +54,12 @@ def update_config():
         service_restart('nfs-kernel-server')
 
 
+@when('endpoint.nfs.joined')
 @when_any('refresh_nfs_mounts',
           'config.changed.mount_options',
           'config.changed.active_units')
 def read_nfs_mounts():
-    mount_interface = endpoint_from_name('nfs')
-    if mount_interface is None:
-        hookenv.log('No mount interface, bailing')
-        return
-
+    mount_interface = endpoint_from_flag('endpoint.nfs.joined')
     hookenv.status_set('maintenance', 'Updating NFS mounts')
     service_is_running = service_running('nfs-kernel-server')
     if service_is_running:

--- a/reactive/nfs.py
+++ b/reactive/nfs.py
@@ -73,10 +73,10 @@ def read_nfs_mounts():
             return
 
     config = hookenv.config()
-    storage_root = config.get('storage_root')
-    mount_options = config.get('mount_options')
+    storage_root = config['storage_root']
+    mount_options = config['mount_options']
     active_ip = None
-    active_units = config.get('active_units', '')
+    active_units = config['active_units']
     need_service = True
 
     if active_units:

--- a/reactive/nfs.py
+++ b/reactive/nfs.py
@@ -10,7 +10,7 @@ from charmhelpers.core.host import (
 )
 from charmhelpers.fetch import apt_install
 from charms.reactive import when, when_not, when_any, set_flag, clear_flag
-from charms.reactive.relations import endpoint_from_flag
+from charms.reactive.relations import endpoint_from_flag, endpoint_from_name
 
 from subprocess import check_output, CalledProcessError
 
@@ -58,7 +58,7 @@ def update_config():
           'config.changed.mount_options',
           'config.changed.active_units')
 def read_nfs_mounts():
-    mount_interface = endpoint_from_flag('endpoint.nfs.joined')
+    mount_interface = endpoint_from_name('nfs')
     if mount_interface is None:
         hookenv.log('No mount interface, bailing')
         return

--- a/reactive/relations/nfs-peer/peers.py
+++ b/reactive/relations/nfs-peer/peers.py
@@ -1,0 +1,29 @@
+from charmhelpers.core import hookenv
+from charms.reactive import Endpoint
+
+
+class NFSPeer(Endpoint):
+
+    def get_peer_info(self, address_key='private-address'):
+        """Return peer information mapped by unit names.
+
+        An example return value is:
+
+        {
+            'nfs/0': {'address': '172.16.0.1'},
+            'nfs/1': {'address': '172.16.0.2'},
+        }
+
+        :param address_key: the key to use to fetch the remote unit's
+            address.
+        :return: a dict mapping unit names to dicts containing peer
+            information, including the address.
+        """
+        info = {
+            hookenv.local_unit(): {'address': hookenv.unit_get(address_key)},
+        }
+        for unit in self.all_joined_units:
+            info[unit.unit_name] = {
+                'address': unit.received_raw.get(address_key),
+            }
+        return info


### PR DESCRIPTION
Assuming that the requiring charms support it, this allows reasonably
graceful migration from one NFS unit to another, along the lines of the
following procedure:

```
$ juju config nfs active_units=<old unit ID>
$ juju add-unit nfs
$ juju config nfs active_units=none
# wait for clients to unmount, then move storage to new unit
$ juju config nfs active_units=<new unit ID>
# wait for clients to mount
$ juju remove-unit <old unit ID>
$ juju config nfs active_units=
```

This involves moving publishing data on the mount relation to
`read_nfs_mounts`, which seems more correct anyway (we shouldn't publish
a mount until it has been exported).